### PR TITLE
Update Zen to 1.2.22 beta release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gunicorn
 openai
 anthropic
 mistralai
-aikido_zen==1.2.21
+aikido_zen==1.2.22b0
 memray


### PR DESCRIPTION
- Removes dependence on the `requests` library